### PR TITLE
Implement basic Liova Flask app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+venv/
+*.db

--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
-# LIOVA
+# Liova
+
+Liova is a Flask web application for refactoring emails using the OpenAI API. Users can create accounts, log in, and rewrite emails with a simple interface. The app displays a diff between the original and refactored email.
+
+## Setup
+
+1. Create a virtual environment and install dependencies:
+
+```bash
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+```
+
+2. Set your OpenAI API key in the environment:
+
+```bash
+export OPENAI_API_KEY=your-key
+```
+
+3. Run the application:
+
+```bash
+python app.py
+```
+
+The app will start on `http://localhost:5000`.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,8 @@
+from liova import create_app, db
+
+app = create_app()
+
+if __name__ == '__main__':
+    with app.app_context():
+        db.create_all()
+    app.run(debug=True)

--- a/liova/__init__.py
+++ b/liova/__init__.py
@@ -1,0 +1,56 @@
+from flask import Flask, render_template
+from flask_sqlalchemy import SQLAlchemy
+from flask_login import LoginManager
+
+# Initialize extensions
+
+db = SQLAlchemy()
+login_manager = LoginManager()
+login_manager.login_view = 'auth.login'
+
+
+def create_app():
+    app = Flask(__name__)
+    app.config['SECRET_KEY'] = 'change-me'
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///liova.db'
+
+    db.init_app(app)
+    login_manager.init_app(app)
+
+    from .models import User
+
+    @login_manager.user_loader
+    def load_user(user_id):
+        return User.query.get(int(user_id))
+
+    from .auth import auth_bp
+    from .email import email_bp
+
+    app.register_blueprint(auth_bp)
+    app.register_blueprint(email_bp)
+
+    @app.route('/')
+    def index():
+        return render_template('index.html')
+
+    @app.route('/packages')
+    def packages():
+        return render_template('packages.html')
+
+    @app.route('/about')
+    def about():
+        return render_template('about.html')
+
+    @app.route('/contact')
+    def contact():
+        return render_template('contact.html')
+
+    @app.route('/faq')
+    def faq():
+        return render_template('faq.html')
+
+    @app.route('/support')
+    def support():
+        return render_template('support.html')
+
+    return app

--- a/liova/auth.py
+++ b/liova/auth.py
@@ -1,0 +1,44 @@
+from flask import Blueprint, render_template, redirect, url_for, request, flash
+from flask_login import login_user, login_required, logout_user
+
+from . import db
+from .models import User
+
+auth_bp = Blueprint('auth', __name__)
+
+
+@auth_bp.route('/register', methods=['GET', 'POST'])
+def register():
+    if request.method == 'POST':
+        username = request.form['username']
+        password = request.form['password']
+        if User.query.filter_by(username=username).first():
+            flash('Username already exists.')
+            return redirect(url_for('auth.register'))
+        user = User(username=username)
+        user.set_password(password)
+        db.session.add(user)
+        db.session.commit()
+        login_user(user)
+        return redirect(url_for('index'))
+    return render_template('register.html')
+
+
+@auth_bp.route('/login', methods=['GET', 'POST'])
+def login():
+    if request.method == 'POST':
+        username = request.form['username']
+        password = request.form['password']
+        user = User.query.filter_by(username=username).first()
+        if user and user.check_password(password):
+            login_user(user)
+            return redirect(url_for('index'))
+        flash('Invalid username or password')
+    return render_template('login.html')
+
+
+@auth_bp.route('/logout')
+@login_required
+def logout():
+    logout_user()
+    return redirect(url_for('index'))

--- a/liova/email.py
+++ b/liova/email.py
@@ -1,0 +1,41 @@
+import difflib
+import os
+import openai
+from flask import Blueprint, render_template, request
+from flask_login import login_required
+
+email_bp = Blueprint('email', __name__)
+
+
+@email_bp.route('/refactor', methods=['GET', 'POST'])
+@login_required
+def refactor():
+    original = ''
+    refactored = ''
+    diff = ''
+    if request.method == 'POST':
+        original = request.form['email']
+        refactored = refactor_email(original)
+        diff = generate_diff(original, refactored)
+    return render_template('refactor.html', original=original,
+                           refactored=refactored, diff=diff)
+
+
+def refactor_email(text: str) -> str:
+    """Use OpenAI API to refactor email text."""
+    try:
+        openai.api_key = os.getenv("OPENAI_API_KEY")
+        response = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=[{"role": "system", "content": "Refactor the email for clarity and professionalism."},
+                     {"role": "user", "content": text}],
+            temperature=0.3,
+        )
+        return response.choices[0].message['content'].strip()
+    except Exception:
+        return text
+
+
+def generate_diff(a: str, b: str) -> str:
+    diff = difflib.ndiff(a.splitlines(), b.splitlines())
+    return '\n'.join(diff)

--- a/liova/models.py
+++ b/liova/models.py
@@ -1,0 +1,16 @@
+from flask_login import UserMixin
+from werkzeug.security import generate_password_hash, check_password_hash
+
+from . import db
+
+
+class User(UserMixin, db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    username = db.Column(db.String(150), unique=True, nullable=False)
+    password_hash = db.Column(db.String(256), nullable=False)
+
+    def set_password(self, password):
+        self.password_hash = generate_password_hash(password)
+
+    def check_password(self, password):
+        return check_password_hash(self.password_hash, password)

--- a/liova/static/css/style.css
+++ b/liova/static/css/style.css
@@ -1,0 +1,17 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+}
+nav {
+    background: #333;
+    padding: 1em;
+}
+nav a {
+    color: #fff;
+    margin-right: 1em;
+    text-decoration: none;
+}
+.container {
+    padding: 1em;
+}

--- a/liova/templates/about.html
+++ b/liova/templates/about.html
@@ -1,0 +1,5 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>About Liova</h2>
+<p>Liova helps you rewrite emails using AI.</p>
+{% endblock %}

--- a/liova/templates/base.html
+++ b/liova/templates/base.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Liova</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
+</head>
+<body>
+    <nav>
+        <a href="{{ url_for('index') }}">Home</a>
+        {% if current_user.is_authenticated %}
+        <a href="{{ url_for('email.refactor') }}">Refactor</a>
+        <a href="{{ url_for('auth.logout') }}">Logout</a>
+        {% else %}
+        <a href="{{ url_for('auth.login') }}">Login</a>
+        <a href="{{ url_for('auth.register') }}">Register</a>
+        {% endif %}
+        <a href="{{ url_for('packages') }}">Packages</a>
+        <a href="{{ url_for('about') }}">About</a>
+        <a href="{{ url_for('contact') }}">Contact</a>
+    </nav>
+    <div class="container">
+        {% with messages = get_flashed_messages() %}
+        {% if messages %}
+        <ul class="flashes">
+            {% for message in messages %}
+            <li>{{ message }}</li>
+            {% endfor %}
+        </ul>
+        {% endif %}
+        {% endwith %}
+        {% block content %}{% endblock %}
+    </div>
+</body>
+</html>

--- a/liova/templates/contact.html
+++ b/liova/templates/contact.html
@@ -1,0 +1,5 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Contact</h2>
+<p>Email us at support@liova.com</p>
+{% endblock %}

--- a/liova/templates/faq.html
+++ b/liova/templates/faq.html
@@ -1,0 +1,5 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>FAQ</h2>
+<p>Frequently asked questions.</p>
+{% endblock %}

--- a/liova/templates/index.html
+++ b/liova/templates/index.html
@@ -1,0 +1,6 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Welcome to Liova</h1>
+<p>Refactor your emails to be more professional and accurate.</p>
+<a href="{{ url_for('auth.register') }}" class="btn">Get Started</a>
+{% endblock %}

--- a/liova/templates/login.html
+++ b/liova/templates/login.html
@@ -1,0 +1,11 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Login</h2>
+<form method="post">
+    <label for="username">Username</label>
+    <input type="text" name="username" id="username" required>
+    <label for="password">Password</label>
+    <input type="password" name="password" id="password" required>
+    <button type="submit">Login</button>
+</form>
+{% endblock %}

--- a/liova/templates/packages.html
+++ b/liova/templates/packages.html
@@ -1,0 +1,14 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Packages</h2>
+<div class="packages">
+    <div class="package">
+        <h3>Free</h3>
+        <p>Basic email refactoring.</p>
+    </div>
+    <div class="package">
+        <h3>Pro</h3>
+        <p>Unlimited refactoring with advanced features.</p>
+    </div>
+</div>
+{% endblock %}

--- a/liova/templates/refactor.html
+++ b/liova/templates/refactor.html
@@ -1,0 +1,14 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Email Refactoring</h2>
+<form method="post">
+    <textarea name="email" rows="8" cols="60">{{ original }}</textarea>
+    <button type="submit">Refactor</button>
+</form>
+{% if refactored %}
+<h3>Refactored Email</h3>
+<pre>{{ refactored }}</pre>
+<h3>Diff</h3>
+<pre>{{ diff }}</pre>
+{% endif %}
+{% endblock %}

--- a/liova/templates/register.html
+++ b/liova/templates/register.html
@@ -1,0 +1,11 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Register</h2>
+<form method="post">
+    <label for="username">Username</label>
+    <input type="text" name="username" id="username" required>
+    <label for="password">Password</label>
+    <input type="password" name="password" id="password" required>
+    <button type="submit">Register</button>
+</form>
+{% endblock %}

--- a/liova/templates/support.html
+++ b/liova/templates/support.html
@@ -1,0 +1,5 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Support</h2>
+<p>For support, contact us at help@liova.com.</p>
+{% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+Flask
+Flask-Login
+Flask-SQLAlchemy
+openai


### PR DESCRIPTION
## Summary
- add Flask application with registration/login, OpenAI email refactor
- store users in SQLite via SQLAlchemy
- implement routes for landing, packages, about, contact, faq, support
- create basic templates and styling
- document setup and OpenAI API key in README

## Testing
- `python -m py_compile $(find liova -name '*.py') app.py`


------
https://chatgpt.com/codex/tasks/task_e_68614f905ba88329961a2608171ebd1d